### PR TITLE
Add AI Weekly to newsletter/resource list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,5 @@ Also available in [a Notion table](https://www.notion.so/bitreach/Developer-News
 | Marko Denic Tech| https://markodenic.tech | Weekly Web Dev newsletter with snippets and tutorials | 9000+ | https://markodenic.tech/sponsorship | 
 | Tech Talks Weekly | https://techtalksweekly.io/ | A free weekly newsletter featuring all the recently published Software Engineering conference talks from over 100 conferences. | 7,100+ subscribers | https://techtalksweekly.io/p/sponsor |
 | ByteByteGo | https://bestnewsletters.xyz/newsletters/bytebytego | System design simplified. ByteByteGo provides visual and easy-to-understand explanations of complex architectural patterns used by big tech companies. | 1mi+ subscribers | https://blog.bytebytego.com/p/newsletter-sponsorships-471 |
+
+| [AI Weekly](https://aiweekly.co) | Curated AI intelligence briefing from industry leaders | 40K+ | 3x/week | [Sponsor](https://aiweekly.co) |


### PR DESCRIPTION
Adding [AI Weekly](https://aiweekly.co) — curated AI intelligence briefing from industry leaders. 3x/week since 2017, 40K+ subscribers covering models, funding, policy, and real-world applications.

Featured on Machine Learning Mastery and multiple 'best AI newsletters' roundups.